### PR TITLE
explicit dependencies hotfixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -164,7 +164,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "dev": true,
       "requires": {
         "util": "0.10.3"
       }
@@ -1846,9 +1845,9 @@
       }
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
       "dev": true
     },
     "component-emitter": {
@@ -2496,6 +2495,11 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
+    "emitter-component": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.1.tgz",
+      "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY="
+    },
     "emoji-regex": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
@@ -2751,9 +2755,9 @@
       }
     },
     "fs-readdir-recursive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
-      "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
       "dev": true
     },
     "fs.realpath": {
@@ -8918,6 +8922,14 @@
         }
       }
     },
+    "stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
+      "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
+      "requires": {
+        "emitter-component": "^1.1.1"
+      }
+    },
     "stream-array": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/stream-array/-/stream-array-1.1.2.tgz",
@@ -9629,7 +9641,6 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.1"
       },
@@ -9637,8 +9648,7 @@
         "inherits": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,14 +28,18 @@
     "url": "git://github.com/EOSIO/eosjs-ecc.git"
   },
   "dependencies": {
+    "assert": "^1.4.1",
     "bigi": "^1.4.2",
     "browserify-aes": "^1.0.6",
     "bs58": "^4.0.1",
     "bytebuffer": "^5.0.1",
+    "cipher-base": "^1.0.4",
     "create-hash": "^1.1.3",
     "create-hmac": "^1.1.6",
     "ecurve": "^1.0.5",
-    "randombytes": "^2.0.5"
+    "inherits": "^2.0.3",
+    "randombytes": "^2.0.5",
+    "stream": "0.0.2"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
This one is not for merge, but for reference.

For whatever reason library can not be used (imported) in simple way from node.js ecosystem, as many dependencies are not inlined into dist package or not visible to consuming packages, which may be caused by babel pipeline.

`assert` usualy fails first, to reproduce try not to use local environment with dependencies installed globally. also, looks like CI and test are not adequate for this problem. Also it looks like node LTS version is not covered by CI.