### PR TITLE
use ripemd160 for electron 4.0.

### DIFF
--- a/src/hash.js
+++ b/src/hash.js
@@ -32,7 +32,7 @@ function HmacSHA256(buffer, secret) {
 }
 
 function ripemd160(data) {
-    return createHash('rmd160').update(data).digest()
+    return createHash('ripemd160').update(data).digest()
 }
 
 // function hash160(buffer) {


### PR DESCRIPTION
Electron 4.0 uses BoringSSL for crypto module.
BoringSSL does not have the alias `rmd160` -> `ripemd160`.
`ripemd160` works in normal OpenSSL node and Electron 4.0.
This minor change should not break any existing function.