### PR TITLE
Speed Up signatures and strengthen verifications

### DIFF
--- a/src/signature.js
+++ b/src/signature.js
@@ -54,7 +54,8 @@ function Signature(r, s, i) {
         return ecdsa.verify(
             curve, dataSha256,
             { r: r, s: s },
-            publicKey.Q
+            publicKey.Q,
+            i
         );
     };
 
@@ -202,17 +203,17 @@ Signature.signHash = function(dataSha256, privateKey, encoding = 'hex') {
     privateKey = PrivateKey(privateKey)
     assert(privateKey, 'privateKey required')
 
-    var der, e, ecsignature, i, lenR, lenS, nonce;
+    var der, e, ecsignature, i, lenR, lenS, nonce, ypar;
     i = null;
     nonce = 0;
     e = BigInteger.fromBuffer(dataSha256);
     while (true) {
-      ecsignature = ecdsa.sign(curve, dataSha256, privateKey.d, nonce++);
+      [ecsignature, ypar] = ecdsa.sign(curve, dataSha256, privateKey.d, nonce++);
       der = ecsignature.toDER();
       lenR = der[3];
       lenS = der[5 + lenR];
       if (lenR === 32 && lenS === 32) {
-        i = ecdsa.calcPubKeyRecoveryParam(curve, e, ecsignature, privateKey.toPublic().Q);
+        i = ypar;// ecdsa.calcPubKeyRecoveryParam
         i += 4;  // compressed
         i += 27; // compact  //  24 or 27 :( forcing odd-y 2nd key candidate)
         break;


### PR DESCRIPTION
78% of the time spent during a signature was to computationally recover the parity of R.y, which was not even checked during the signature verification. This change reads ans saves the R.y parity to save a lot of time during a signature. Signatures are now 4.5 times faster.
Also, now it checks the signature parity flags during a verification, in virtually no time. This checks prevents transaction malleability, because anyone can trivially build a different signature, without knowing the private key, since the parity flag wasn't checked at verification time.
