### PR TITLE
Adding fallback name for ripemd160

### DIFF
--- a/src/hash.js
+++ b/src/hash.js
@@ -32,7 +32,11 @@ function HmacSHA256(buffer, secret) {
 }
 
 function ripemd160(data) {
-    return createHash('rmd160').update(data).digest()
+    try{
+	    return createHash('rmd160').update(data).digest();
+    } catch(e){
+	    return createHash('ripemd160').update(data).digest();
+    }
 }
 
 // function hash160(buffer) {


### PR DESCRIPTION
In certain environments it seems that ripemd160 is failing citing a "Digest method not supported".
https://github.com/crypto-browserify/createHash doesn't *always* accept `rmd160` as the ripemd string, and requires the full `ripemd160`.