### PR TITLE
Fix Version and Main in Package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eosjs-ecc",
-  "version": "4.0.4-beta1",
+  "version": "4.0.7",
   "description": "Elliptic curve cryptography functions",
   "keywords": [
     "ECC",
@@ -11,11 +11,11 @@
     "Encryption",
     "Decryption"
   ],
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "files": [
     "README.md",
     "docs",
-    "lib"
+    "src"
   ],
   "scripts": {
     "test": "mocha --use_strict src/*.test.js",


### PR DESCRIPTION
Versions got screwed up when a bunch of different versions got merged. This just updates the version number and adds the 'src' folder to the files package. Allowing for the correct version of this repository to be used; and its latest changes from two months ago; which are currently **inaccessible**.